### PR TITLE
Add Oriole

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ A curated list of awesome Swift frameworks, libraries and software. Inspired by 
 * [Dollar.swift](https://github.com/ankurp/Dollar.swift) - A functional tool-belt for Swift Language similar to Lo-Dash or Underscore in Javascript.
 * [swiftz](https://github.com/maxpow4h/swiftz) - A Swift library for functional programming.
 * [ExSwift](https://github.com/pNre/ExSwift) - JavaScript (Lo-Dash, Underscore) & Ruby inspired set of Swift extensions for standard types and classes.
+* [Oriole](https://github.com/tptee/Oriole) - A functional utility belt implemented as Swift 2.0 protocol extensions.
 * [Observable-Swift](https://github.com/slazyk/Observable-Swift) - Value Observing and Events for Swift.
 * [PromiseKit](https://github.com/mxcl/PromiseKit) - A delightful Promises implementation for iOS.
 * [Promissum](https://github.com/tomlokhorst/Promissum) - Promise library with functional combinators like `map`, `flatMap`, `whenAll` & `whenAny`.


### PR DESCRIPTION
Oriole is a set of protocol extensions that add useful helper methods to Swift collections. Oriole resembles libraries like Dollar and ExSwift (which in turn take inspiration from Lodash), but with some ideological differences:

- Oriole uses Swift 2.0's new protocol extensions to provide more natural APIs.
- Oriole strives to be as generic as possible. Most methods extend CollectionType. Oriole extends concrete collections like Array, Set, and Dictionary only if necessary.
- Oriole fills in gaps in the Swift standard library. If a method is trivially reproducible by methods in the standard library, it is not included.
- Oriole prefers to implement functional solutions to problems. However, if an imperative solution is elegant and significantly more performant, it will replace the functional solution.