### PR TITLE
Add Sorry

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A curated list of awesome Swift frameworks, libraries and software. Inspired by 
 	- [Testing](#testing)
 	- [Documentation](#documentation)
 	- [Events](#events)
+	- [Permissions](#permissions)
 	- [Queue](#queue)
 	- [HTTP](#http)
 	- [Caching](#caching)
@@ -98,6 +99,11 @@ A curated list of awesome Swift frameworks, libraries and software. Inspired by 
 * [EmitterKit](https://github.com/aleclarson/emitter-kit) - An elegant event framework built in Swift
 * [Swift-Custom-Events](https://github.com/StephenHaney/Swift-Custom-Events) - A very simple way to implement Backbone.js style custom event listeners and triggering in Swift for iOS development.
 * [Kugel](https://github.com/TakeScoop/Kugel) - A glorious Swift wrapper around NSNotificationCenter
+
+## Permissions
+*Libraries for asking user permissions.*
+
+* [Sorry](https://github.com/delba/Sorry) - Ask for iOS permissions through a single, uniform interface.
 
 ## Queue
 *Libraries for working with event and task queues.*


### PR DESCRIPTION
Sorry provides a single, uniform interface to ask for iOS permissions. I love PermissionScope but it's sometimes too opinionated about your interface...

**The simplest example:**

```swift
let permission = Permission(.Contacts)

permission.request { status in
    print(status)
}
```

**Configure the alerts:**

```swift
permission.configureAlert(.Denied) { alert in
    alert.title = "You denied access to your contacts"
    alert.message = "Please allow access in the settings app"
    alert.cancel = "Cancel"
    alert.settings = "Settings"
}
```

**Sorry has some helpers too :)**

```swift
let button = PermissionButton(.Contacts)

button.setTitles([
    .Authorized: "Authorized",
    .Denied: "Denied"
])

// etc.
```

**And you can create some permissions set**

Let's say you want to know if the user allowed access to both your photos **and** your events:

```swift
let photos = PermissionButton(.Photos)
let events = PermissionButton(.Events)

let permissionSet = PermissionSet(photos, events)
```  

More in the [README](https://github.com/delba/Sorry)
