### PR TITLE
Added Simplicity

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ A curated list of awesome Swift frameworks, libraries and software. Inspired by 
 *Libraries for accessing third party APIs.*
 
 * [GooglePlacesAutocomplete](https://github.com/watsonbox/ios_google_places_autocomplete) - Simple Google Places address entry for iOS.
+* [Simplicity](https://github.com/SimplicityMobile/Simplicity) - A simple way to implement Facebook and Google login in your iOS and OS X apps.
 * [Swifter](https://github.com/mattdonnelly/Swifter) - A Twitter framework for iOS & OS X written in Swift
 * [SwiftIB](https://github.com/kcome/SwiftIB) - An InteractiveBrokers API Library for OS X written in Swift. InteractiveBrokers is one of a few, if not the best, brokerage company provide Gateway+API solution for traders.
 


### PR DESCRIPTION
Simplicity is a replacement for the Facebook / Google SDKs, and just implements Facebook / Google login in a lightweight manner. It's extensible and will support other major authentication providers in the future. 

I'd love to see this in Awesome-Swift!