### PR TITLE
add Benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ A curated list of awesome Swift frameworks, libraries and software. Inspired by 
 * [XCGLogger](https://github.com/DaveWoodCom/XCGLogger) - A debug log framework for use in Swift projects.
 * [Swell](https://github.com/hubertr/Swell) - A logging utility for Swift and Objective C.
 * [Log](https://github.com/delba/Log) - A logging tool with built-in themes, formatters, and a nice API to define your owns.
+* [Benchmark](https://github.com/WorldDownTown/Benchmark) - The Benchmark⏲ module provides methods to measure and report the time used to execute Swift code.
 
 ## Third Party APIs
 *Libraries for accessing third party APIs.*


### PR DESCRIPTION
- **Project Name**: Benchmark
- **Project URL**: https://github.com/WorldDownTown/Benchmark
- **Project Description**: The Benchmark module provides methods to measure and report the time used to execute Swift code.
- **Why it should be added to `awesome-swift`**: I created this micro-library for time profiling swift functions.
It would be great if I could add it to the list for `awesome-swift`!
How does it look?
