### PR TITLE
Added WindowAlert library to UI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ A curated list of awesome Swift frameworks, libraries and software. Inspired by 
 * [SAHistoryNavigationViewController](https://github.com/szk-atmosphere/SAHistoryNavigationViewController) - SAHistoryNavigationViewController realizes iOS task manager like UI in UINavigationContoller.
 * [WobbleView](https://github.com/inFullMobile/WobbleView) - Implementation of wobble effect for any view in app.
 * [SimpleAlert](https://github.com/KyoheiG3/SimpleAlert) - Customizable simple Alert and simple ActionSheet for Swift
+* [WindowAlert] (https://github.com/DrBreen/WindowAlert) - Helper class for UIAlertController to simplify it's presentation using dedicated window for alert.
 
 ## Files
 


### PR DESCRIPTION
**What is is?**
WindowAlert is a library to help you dealing with presenting UIAlertController when there's a lot of UIViewControllers and it can be quite unclear which one is the topmost.

**Where's the source code?**
[DrBreen/WindowAlert](https://github.com/DrBreen/WindowAlert)

**What exactly does it do?**
To simplify UIAlertController presentation, it creates a separate UIWindow with transparent root view controller, and then presents UIAlertController on top of it, so you won't have to deal with this nasty "Warning: Attempt to present < viewController: 0x1337beef > on < ViewController: 0xcafebeef> whose view is not in the window hierarchy!" 

**How does it differ from [SimpleAlert](https://github.com/KyoheiG3/SimpleAlert) and [EZAlertController](https://github.com/thellimist/EZAlertController)?**
Unlike SimpleAlert, WindowAlert uses native UIAlertController implementation, so any behavior/design changes will act correct automatically(for example, it will automatically display less-rounded UIAlertController on iOS 8 and more rounded one on iOS 9), without the need to do it yourself.

And unlike EZAlertController, WindowAlert doesn't try to pull topmost view controller - which sometimes may fail. 
Instead, it has a set of a constructors with several options to instantiate WindowAlert:
* Do not provide anything, let the WindowAlert try to pull UIWindow from application delegate to inherit size and tint color from it(may fail if app delegate or root window is missing, so it returns Optional to prevent runtime crashes)
* Explicitly provide UIWindow to inherit size and color from
* Explicitly provide tint color and size of alert window

**What else this library can offer?**
* Comprehensive documentation
* Delegate for WindowAlert to notify the app about WindowAlert visibility events
* Optional "tap outside WindowAlert to dismiss" behavior
* You can change UIWindow level for WindowAlert