### PR TITLE
Add NoOptionalInterpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ A curated list of awesome Swift frameworks, libraries and software. Inspired by 
 * [EZSwiftExtensions](https://github.com/goktugyil/EZSwiftExtensions) - :smirk: How Swift standard types and classes were supposed to work.
 * [BFKit-Swift](https://github.com/FabrizioBrancati/BFKit-Swift) - A collection of useful classes to develop Apps faster.
 * [Sugar](https://github.com/hyperoslo/Sugar) - Something sweet that goes great with your Cocoa.
+* [NoOptionalInterpolation](https://github.com/T-Pham/NoOptionalInterpolation) - Get rid of "Optional(...)" and "nil" in string interpolation. Easy pluralization.
 
 ## Misc
 


### PR DESCRIPTION
NoOptionalInterpolation gets rid of "Optional(...)" and "nil" in string interpolation and makes pluralization easier.

```swift
import NoOptionalInterpolation

let n: Int? = 1
let t: String? = nil
let s: String? = "string1"
let o: String?? = "string2"

let i = "\(n) \(t) \(s) \(o)"
print(i) // 1  string1 string2
```

```swift
let age = 42
let text = "I am \(age ~ "year") old" // "I am 42 years old"
```