### PR TITLE
Add WWDC17-Recap

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Various resources, such as books, websites and articles, for improving your Swif
 * [LearnSwift.tips](http://www.learnswift.tips/) - A curated list of helpful resources to learn Swift. Tutorials, Code Samples, References.
 * [Hacking with Swift](https://www.hackingwithswift.com/) - a complete Swift training course that teaches you app development through 36 hands-on projects, for free.
 * [SwiftLang](http://swiftlang.eu) - a Swift Resource Center & Community.
+* [WWDC17-Recap](https://github.com/erenkabakci/WWDC17-Recap) - Markdown collection repo for the sessions taking place at WWDC17.
 
 
 ## Swift Books


### PR DESCRIPTION
I thought it would be useful to add WWDC-Recap repo since WWDC sessions are very valuable but they are only in vide format. Markdown collections could be helpful for people looking for summaries. I am not sure about Swift Websites section. Feel free to change.