### PR TITLE
Added TopicEventBugs to Events category

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ A curated list of awesome Swift frameworks, libraries and software. Inspired by 
 ## Events
 *Libraries for one-to-many communications.*
 
+* [TopicEventBus](https://github.com/mcmatan/topicEventBus) - Publish–subscribe design pattern implementation framework, with an ability to publish events by topic.
 * [Caravel](https://github.com/coshx/caravel) - A Swift event bus for UIWebView and JS
 * [EmitterKit](https://github.com/aleclarson/emitter-kit) - An elegant event framework built in Swift
 * [Swift-Custom-Events](https://github.com/StephenHaney/Swift-Custom-Events) - A very simple way to implement Backbone.js style custom event listeners and triggering in Swift for iOS development.


### PR DESCRIPTION
I was searching for a way of implementing a publish-subscribe design pattern, topic-based, and results have not pleased me. So I created TopicEventBus. Hopefully, more people can benefit from it, I would love to hear your feedback 